### PR TITLE
Implement support for Telnet TTYPE (Terminal Type) option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ Example .env file:
 TELNET_HOST=127.0.0.1       # Required | the IP of your MUD
 TELNET_PORT=23              # Required | the PORT of your MUD
 SOCKET_ROOT=/socket.io      # Required | the named socket for
-HOST=0.0.0.0                # Optional, defaults to '0.0.0.0' | the IP the backend will listen for
-PORT=5000                   # Optional, defaults to 5000 | the PORT the backend will listen for
-TELNET_TLS=false            # Optional, defaults to 'false' | set this to true if you want a secure connection
-SOCKET_TIMEOUT=900000       # Optional, defaults to 900000 (15 min) | timeout for any lost frontend<->backend connection
-CHARSET=utf8                # Optional, defaults to 'utf8'
+NAME=webmud3                # Optional | defaults to 'webmud3'        | the name of the client
+HOST=0.0.0.0                # Optional | defaults to '0.0.0.0'        | the IP the backend will listen for
+PORT=5000                   # Optional | defaults to 5000             | the PORT the backend will listen for
+TELNET_TLS=false            # Optional | defaults to 'false'          | set this to true if you want a secure connection
+SOCKET_TIMEOUT=900000       # Optional | defaults to 900000 (15 min)  | timeout for any lost frontend <-> backend connection
 ```
 
 > [!TIP]

--- a/backend/src/core/environment/environment.ts
+++ b/backend/src/core/environment/environment.ts
@@ -21,6 +21,7 @@ export class Environment implements IEnvironment {
   public readonly socketRoot: string;
   public readonly socketTimeout: number;
   public readonly environment: 'production' | 'development';
+  public readonly name: string;
 
   /**
    * Private constructor to enforce singleton pattern.
@@ -63,6 +64,8 @@ export class Environment implements IEnvironment {
     this.environment = environment;
 
     this.projectRoot = resolveModulePath('../../../main.js');
+
+    this.name = String(getEnvironmentVariable('NAME', false, 'webmud3b'));
 
     logger.info('[Environment] initialized', this);
   }

--- a/backend/src/core/environment/types/environment-keys.ts
+++ b/backend/src/core/environment/types/environment-keys.ts
@@ -1,6 +1,7 @@
 export type EnvironmentKeys =
   | 'HOST' // Optional | defaults to '0.0.0.0' | the IP the backend will listen for
   | 'PORT' // Optional | defaults to 5000 | the PORT the backend will listen for
+  | 'NAME' // Required | the name of your client. Will be send to the MUD. Defaults to 'webmud3b'
   | 'TELNET_HOST' // Required | the IP of your MUD
   | 'TELNET_PORT' // Required | the PORT of your MUD
   | 'TELNET_TLS' // Optional | defaults to 'false' | set this to true if you want a secure connection

--- a/backend/src/core/environment/types/environment.ts
+++ b/backend/src/core/environment/types/environment.ts
@@ -2,11 +2,9 @@ export interface IEnvironment {
   readonly telnetHost: string;
   readonly telnetPort: number;
   readonly telnetTLS: boolean;
-
+  readonly name: string;
   readonly projectRoot: string;
   readonly socketRoot: string;
-
   readonly socketTimeout: number;
-
   readonly environment: 'production' | 'development';
 }

--- a/backend/src/core/middleware/use-sockets.ts
+++ b/backend/src/core/middleware/use-sockets.ts
@@ -13,5 +13,6 @@ export const useSockets = (
     telnetPort: environment.telnetPort,
     useTelnetTls: environment.telnetTLS,
     socketRoot: environment.socketRoot,
+    clientName: environment.name,
   });
 };

--- a/backend/src/core/sockets/socket-manager.ts
+++ b/backend/src/core/sockets/socket-manager.ts
@@ -27,6 +27,7 @@ export class SocketManager extends Server<
       telnetPort: number;
       useTelnetTls: boolean;
       socketRoot: string;
+      clientName: string;
     },
   ) {
     super(server, {
@@ -144,6 +145,7 @@ export class SocketManager extends Server<
           this.managerOptions.telnetHost,
           this.managerOptions.telnetPort,
           this.managerOptions.useTelnetTls,
+          this.managerOptions.clientName,
         );
 
         telnetClient.on('data', (data: string | Buffer) => {

--- a/backend/src/features/telnet/telnet-client.ts
+++ b/backend/src/features/telnet/telnet-client.ts
@@ -13,6 +13,7 @@ import { handleEchoOption } from './utils/handle-echo-option.js';
 import { handleLinemodeOption } from './utils/handle-linemode-option.js';
 import { handleNawsOption } from './utils/handle-naws-option.js';
 import { handleSGAOption } from './utils/handle-sga-option.js';
+import { handleTTypeOption } from './utils/handle-ttype-option.js';
 import { TelnetSocketWrapper } from './utils/telnet-socket-wrapper.js';
 
 type TelnetClientEvents = {
@@ -74,6 +75,7 @@ export class TelnetClient extends EventEmitter<TelnetClientEvents> {
       [TelnetOptions.TELOPT_NAWS, handleNawsOption(this.telnetSocket)],
       [TelnetOptions.TELOPT_SGA, handleSGAOption(this.telnetSocket)],
       [TelnetOptions.TELOPT_LINEMODE, handleLinemodeOption(this.telnetSocket)],
+      [TelnetOptions.TELOPT_TTYPE, handleTTypeOption(this.telnetSocket)],
     ]);
 
     this.telnetSocket.on('connect', () => this.handleConnect());

--- a/backend/src/features/telnet/telnet-client.ts
+++ b/backend/src/features/telnet/telnet-client.ts
@@ -55,7 +55,12 @@ export class TelnetClient extends EventEmitter<TelnetClientEvents> {
    * @param {number} telnetPort - The port number of the Telnet server.
    * @param {boolean} useTls - Indicates whether to use TLS encryption for the connection.
    */
-  constructor(telnetHost: string, telnetPort: number, useTls: boolean) {
+  constructor(
+    telnetHost: string,
+    telnetPort: number,
+    useTls: boolean,
+    clientName: string,
+  ) {
     super();
 
     const telnetConnection = createTelnetConnection(
@@ -75,7 +80,10 @@ export class TelnetClient extends EventEmitter<TelnetClientEvents> {
       [TelnetOptions.TELOPT_NAWS, handleNawsOption(this.telnetSocket)],
       [TelnetOptions.TELOPT_SGA, handleSGAOption(this.telnetSocket)],
       [TelnetOptions.TELOPT_LINEMODE, handleLinemodeOption(this.telnetSocket)],
-      [TelnetOptions.TELOPT_TTYPE, handleTTypeOption(this.telnetSocket)],
+      [
+        TelnetOptions.TELOPT_TTYPE,
+        handleTTypeOption(this.telnetSocket, clientName),
+      ],
     ]);
 
     this.telnetSocket.on('connect', () => this.handleConnect());

--- a/backend/src/features/telnet/utils/handle-ttype-option.ts
+++ b/backend/src/features/telnet/utils/handle-ttype-option.ts
@@ -4,23 +4,18 @@ import { TelnetOptions } from '../models/telnet-options.js';
 import { TelnetControlSequences } from '../types/telnet-control-sequences.js';
 import { TelnetOptionHandler } from '../types/telnet-option-handler.js';
 import { TelnetOptionResult } from '../types/telnet-option-result.js';
+import { TelnetSubnegotiationResult } from '../types/telnet-subnegotiation-result.js';
 
 const DEFAULT_TERMINAL_NAME = 'webmud3b';
+
+enum TelnetTTypeSubnogiation {
+  TTYPE_SEND = 1,
+}
 
 const handleTTypeDo = (socket: TelnetSocket) => (): TelnetOptionResult => {
   socket.writeWill(TelnetOptions.TELOPT_TTYPE);
 
-  const buffer = Buffer.from(DEFAULT_TERMINAL_NAME);
-
-  socket.writeSub(TelnetOptions.TELOPT_TTYPE, buffer);
-
-  return {
-    controlSequence: TelnetControlSequences.WONT,
-    subNegotiationResult: {
-      clientChunk: buffer,
-      clientOption: DEFAULT_TERMINAL_NAME,
-    },
-  };
+  return { controlSequence: TelnetControlSequences.WILL };
 };
 
 const handleTTypeDont = (socket: TelnetSocket) => (): TelnetOptionResult => {
@@ -42,6 +37,23 @@ const handleTTypeWont = (socket: TelnetSocket) => (): TelnetOptionResult => {
   return { controlSequence: TelnetControlSequences.DONT };
 };
 
+const handleTTypeSub =
+  (socket: TelnetSocket) =>
+  (serverChunk: Buffer): TelnetSubnegotiationResult => {
+    if (new Uint8Array(serverChunk)[0] === TelnetTTypeSubnogiation.TTYPE_SEND) {
+      const buffer = Buffer.from(DEFAULT_TERMINAL_NAME);
+
+      socket.writeSub(TelnetOptions.TELOPT_TTYPE, buffer);
+
+      return {
+        clientChunk: buffer,
+        clientOption: DEFAULT_TERMINAL_NAME,
+      };
+    }
+
+    return null;
+  };
+
 export const handleTTypeOption = (
   socket: TelnetSocket,
 ): TelnetOptionHandler => {
@@ -50,5 +62,6 @@ export const handleTTypeOption = (
     handleDont: handleTTypeDont(socket),
     handleWill: handleTTypeWill(socket),
     handleWont: handleTTypeWont(socket),
+    handleSub: handleTTypeSub(socket),
   };
 };

--- a/backend/src/features/telnet/utils/handle-ttype-option.ts
+++ b/backend/src/features/telnet/utils/handle-ttype-option.ts
@@ -6,8 +6,6 @@ import { TelnetOptionHandler } from '../types/telnet-option-handler.js';
 import { TelnetOptionResult } from '../types/telnet-option-result.js';
 import { TelnetSubnegotiationResult } from '../types/telnet-subnegotiation-result.js';
 
-const DEFAULT_TERMINAL_NAME = 'webmud3b';
-
 enum TelnetTTypeSubnogiation {
   TTYPE_SEND = 1,
 }
@@ -38,16 +36,16 @@ const handleTTypeWont = (socket: TelnetSocket) => (): TelnetOptionResult => {
 };
 
 const handleTTypeSub =
-  (socket: TelnetSocket) =>
+  (socket: TelnetSocket, clientName: string) =>
   (serverChunk: Buffer): TelnetSubnegotiationResult => {
     if (new Uint8Array(serverChunk)[0] === TelnetTTypeSubnogiation.TTYPE_SEND) {
-      const buffer = Buffer.from(DEFAULT_TERMINAL_NAME);
+      const buffer = Buffer.from(clientName);
 
       socket.writeSub(TelnetOptions.TELOPT_TTYPE, buffer);
 
       return {
         clientChunk: buffer,
-        clientOption: DEFAULT_TERMINAL_NAME,
+        clientOption: clientName,
       };
     }
 
@@ -56,12 +54,13 @@ const handleTTypeSub =
 
 export const handleTTypeOption = (
   socket: TelnetSocket,
+  clientName: string,
 ): TelnetOptionHandler => {
   return {
     handleDo: handleTTypeDo(socket),
     handleDont: handleTTypeDont(socket),
     handleWill: handleTTypeWill(socket),
     handleWont: handleTTypeWont(socket),
-    handleSub: handleTTypeSub(socket),
+    handleSub: handleTTypeSub(socket, clientName),
   };
 };

--- a/backend/src/features/telnet/utils/handle-ttype-option.ts
+++ b/backend/src/features/telnet/utils/handle-ttype-option.ts
@@ -1,0 +1,54 @@
+import { TelnetSocket } from 'telnet-stream';
+
+import { TelnetOptions } from '../models/telnet-options.js';
+import { TelnetControlSequences } from '../types/telnet-control-sequences.js';
+import { TelnetOptionHandler } from '../types/telnet-option-handler.js';
+import { TelnetOptionResult } from '../types/telnet-option-result.js';
+
+const DEFAULT_TERMINAL_NAME = 'webmud3b';
+
+const handleTTypeDo = (socket: TelnetSocket) => (): TelnetOptionResult => {
+  socket.writeWill(TelnetOptions.TELOPT_TTYPE);
+
+  const buffer = Buffer.from(DEFAULT_TERMINAL_NAME);
+
+  socket.writeSub(TelnetOptions.TELOPT_TTYPE, buffer);
+
+  return {
+    controlSequence: TelnetControlSequences.WONT,
+    subNegotiationResult: {
+      clientChunk: buffer,
+      clientOption: DEFAULT_TERMINAL_NAME,
+    },
+  };
+};
+
+const handleTTypeDont = (socket: TelnetSocket) => (): TelnetOptionResult => {
+  socket.writeWont(TelnetOptions.TELOPT_TTYPE);
+
+  return { controlSequence: TelnetControlSequences.WONT };
+};
+
+const handleTTypeWill = (socket: TelnetSocket) => (): TelnetOptionResult => {
+  socket.writeDont(TelnetOptions.TELOPT_TTYPE);
+
+  // This makes no sense since WE are giving the type of the terminal
+  return { controlSequence: TelnetControlSequences.DONT };
+};
+
+const handleTTypeWont = (socket: TelnetSocket) => (): TelnetOptionResult => {
+  socket.writeDont(TelnetOptions.TELOPT_TTYPE);
+
+  return { controlSequence: TelnetControlSequences.DONT };
+};
+
+export const handleTTypeOption = (
+  socket: TelnetSocket,
+): TelnetOptionHandler => {
+  return {
+    handleDo: handleTTypeDo(socket),
+    handleDont: handleTTypeDont(socket),
+    handleWill: handleTTypeWill(socket),
+    handleWont: handleTTypeWont(socket),
+  };
+};


### PR DESCRIPTION
##  Description
This PR adds support for the Telnet TTYPE (Terminal Type) option, allowing the client to communicate its terminal type to the server.

The hardcoded value for this Option is now "webmud3b".

Fixes #126 