### PR TITLE
Remove Lowercase Input Manipulation

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,6 +3,7 @@ name: Build and Test
 on:
   pull_request:
     branches: [develop]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/frontend/src/app/core/mud/mud-client/mud-client.component.ts
+++ b/frontend/src/app/core/mud/mud-client/mud-client.component.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { MudInputComponent } from '../components/mud-input/mud-input.component';
 import { MudService } from '../mud.service';
 import { IMudMessage } from '../types/mud-message';
-import { isSecureString, SecureString } from '@mudlet3/frontend/shared';
+import { SecureString } from '@mudlet3/frontend/shared';
 
 @Component({
   selector: 'app-mud-client',
@@ -81,15 +81,7 @@ export class MudclientComponent {
   // }
 
   protected onInputReceived(message: string | SecureString) {
-    // This is a workaround for the first letter being capitalized - remove this line after implementation in the mud itself
-    // See https://github.com/mystiker/webmud3/issues/48
-    const lowerCaseMessage = isSecureString(message)
-      ? message
-      : message.length >= 2
-        ? message.charAt(0).toLowerCase() + message.slice(1)
-        : message;
-
-    this.mudService.sendMessage(lowerCaseMessage);
+    this.mudService.sendMessage(message);
   }
 
   @HostListener('document:keydown', ['$event'])


### PR DESCRIPTION
This PR removes the logic in the frontend that automatically converted two-character inputs to lowercase. The MUD backend now handles lowercasing where applicable, making this frontend behavior redundant.

### Changes
- Deleted the code responsible for automatic lowercasing of two-character inputs in the frontend.
- Verified that the frontend no longer modifies input case automatically.
- Confirmed compatibility with the MUD backend's new handling of lowercasing.

Fixes #139